### PR TITLE
Change: Do not turn on recentf-mode

### DIFF
--- a/recentf-ext.el
+++ b/recentf-ext.el
@@ -106,8 +106,6 @@
   :group 'emacs)
 (require 'recentf)
 
-(recentf-mode 1)
-
 ;;; [2009/03/01] (@* "`recentf' as most recently USED files")
 (defun recentf-push-buffers-in-frame ()
   (walk-windows


### PR DESCRIPTION
recentf-ext.el now include `(recentf-mode 1)` which turn on recentf-mode.
This is problematic with byte-compiling init file.
If init file is following code, recentf file will be overwritten even when init file is byte-compiled.
And the overwritten recentf file only has 20 items at most (because default `recentf-max-saved-items` used).
```elisp
(package-initialize)

(require 'recentf-ext)

(custom-set-variables
 ;; custom-set-variables was added by Custom.
 ;; If you edit it by hand, you could mess it up, so be careful.
 ;; Your init file should contain only one such instance.
 ;; If there is more than one, they won't work right.
 '(package-archives
   (quote
    (("gnu" . "https://elpa.gnu.org/packages/")
     ("melpa" . "https://melpa.org/packages/"))))
 '(package-selected-packages (quote (flycheck recentf-ext)))
 '(recentf-max-saved-items 100))
(custom-set-faces
 ;; custom-set-faces was added by Custom.
 ;; If you edit it by hand, you could mess it up, so be careful.
 ;; Your init file should contain only one such instance.
 ;; If there is more than one, they won't work right.
 )
```
```sh
emacs -batch --eval '(package-initialize)' -f batch-byte-compile .emacs
```

Open init file with flycheck-mode cause also this.
(but overwrittern recentf file by flycheck will be overwritten again with `recentf-list`, when emacs exit)

I think removing `(recentf-mode 1)` is better than to letting users write `(eval-and-compile (setq recentf-max-saved-items 100))`.